### PR TITLE
Fix trailer

### DIFF
--- a/js-comint.el
+++ b/js-comint.el
@@ -227,3 +227,5 @@ Javascript source.
 
 "
   (use-local-map inferior-js-mode-map))
+
+;;; js-comint.el ends here


### PR DESCRIPTION
No idea why package.el wants this comment, but it does. Without this,
the file cannot be installed using e.g. M-x
package-install-from-buffer
