### PR TITLE
Add support for nvm to js-comint

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,23 +1,96 @@
-* js-comint (version 0.0.2)
-It's only a bug fix version of [[http://js-comint-el.sourceforge.net/][js-cominit 0.0.1]].
+* js-comint.el: Run a JavaScript interpreter in an inferior process window
 
-Since it's not been updated for about five years. There is some compatibility issue with latest node.js.
+The first release, [[http://js-comint-el.sourceforge.net/][js-cominit 0.0.1, is hosted on sourceforge]] but it has not
+been updated in five years.
 
-That's what I will fix. I intend to keep it in maintaining mode and avoid adding any new command.
+* History:
+ + Version 0.0.3:
+   - add support to select node.js versions using [[https://github.com/rejeep/nvm.el][nvm.el]]
+ + Version 0.0.2:
+   - hosted on https://github.com/redguardtoo/js-comint
+   - use [[https://nodejs.org][node.js]] by default.
+   - when loading file, detect what API to be used automatically
+ + Version 0.0.1:
+   - original js-comint hosted on http://js-comint-el.sourceforge.net/
 
-* Features added by me
-- Use node.js by default.
-- when loading file, detect what API to be used automatically
+* Installation
+** Direct download of js-comint.el
 
-* Set up
 Place the js-cominit.el somewhere say "~/mylisp/"
+
 #+BEGIN_SRC elisp
 (add-to-list 'load-path "~/mylisp/")
 (require 'js-comint)
-;; if use node.js, we need nice output
-(setenv "NODE_NO_READLINE" "1")
+#+END_SRC
+
+** Using [[http://www.emacswiki.org/emacs/ELPA][ELPA]]
+
+#+BEGIN_SRC elisp
+(require 'package)
+(package-initialize)
+(add-to-list 'package-archives
+             '("melpa" . "http://melpa.org/packages/"))
+(package-install 'js-comint)
+(require 'js-comint)
+#+END_SRC
+
+** Using [[https://github.com/cask/cask][Cask]]
+
+Add js-comint to your Cask file:
+
+#+BEGIN_SRC elisp
+(depends-on "js-comint")
 #+END_SRC
 
 * Usage
-Check it's [[http://js-comint-el.sourceforge.net/][original documentation on sourceforge]].
+After installation, do M-x run-js to create a comint buffer with the
+JavaScript interpreter.
 
+* Customization
+
+You can set the `inferior-js-program-command' string
+and the `inferior-js-program-arguments' list to the executable that runs
+the JS interpreter and the arguments to pass to it respectively.
+
+E.g., the default is:
+
+#+BEGIN_SRC elisp
+(setq inferior-js-program-command "node")
+(setq inferior-js-program-arguments '("--interactive"))
+#+END_SRC
+
+Note that in the example above, the version of node that is picked up will be
+the first found in `exec-path'.
+
+But you could use Rhino or Spidermonkey or whatever you want.
+E.g. to set up the Rhino JAR downloaded from https://github.com/mozilla/rhino, do
+
+#+BEGIN_SRC elisp
+(setq inferior-js-program-command "java")
+(setq inferior-js-program-arguments '("-jar" "/absolute/path/to/rhino/js.jar"))
+#+END_SRC
+
+If you have nvm, you can select the versions of node.js installed and run
+them. This is done thanks to nvm.el
+To enable nvm support, run
+
+#+BEGIN_SRC elisp
+(js-do-use-nvm)
+#+END_SRC
+
+The first time you start the JS interpreter with run-js, you will be asked
+to select a version of node.js
+If you want to change version of node js, run (js-select-node-version)
+
+You can add  the following couple of lines to your .emacs to take advantage of
+cool keybindings for sending things to the javascript interpreter inside
+of Steve Yegge's most excellent js2-mode.
+
+#+BEGIN_SRC elisp
+(add-hook 'js2-mode-hook '(lambda ()
+                            (local-set-key "\C-x\C-e" 'js-send-last-sexp)
+                            (local-set-key "\C-\M-x" 'js-send-last-sexp-and-go)
+                            (local-set-key "\C-cb" 'js-send-buffer)
+                            (local-set-key "\C-c\C-b" 'js-send-buffer-and-go)
+                            (local-set-key "\C-cl" 'js-load-file-and-go)))
+#+END_SRC

--- a/js-comint.el
+++ b/js-comint.el
@@ -1,19 +1,24 @@
-;;; js-comint.el --- Run javascript in an inferior process window.
+;;; js-comint.el --- Run a JavaScript interpreter in an inferior process window.
 
 ;;; Copyright (C) 2008 Paul Huff
+;;; Copyright (C) 2015 Stefano Mazzucco
 
-;;; Author: Paul Huff <paul.huff@gmail.com>
+;;; Author: Paul Huff <paul.huff@gmail.com>, Stefano Mazzucco <MY FIRST NAME - AT - CURSO - DOT - RE>
 ;;; Maintainer: Chen Bin <chenbin.sh@gmail.com>
 ;;; Created: 15 Feb 2014
-;;; Version: 0.0.2
-;;; Package-Requires: ()
-;;; Keywords: javascript, inferior-mode, convenience
+;;; Version: 0.0.3
+;;; URL: https://github.com/redguardtoo/js-comint
+;;; Package-Requires: ((nvm "0.2.0"))
+;;; Keywords: javascript, node, inferior-mode, convenience
 
+;; This file is NOT part of GNU Emacs.
+
+;;; License:
 
 ;; js-comint.el is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as
 ;; published by the Free Software Foundation; either version 2, or
-;; {at your option} any later version.
+;; at your option any later version.
 
 ;; js-comint.el is distributed in the hope that it will be useful, but
 ;; WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -30,49 +35,70 @@
 ;;   USA
 
 ;;; Commentary:
-;;; js-comint.el let's you run an inferior javascript process in emacs,
-;;; and defines a few functions for sending javascript input to it quickly.
+;;; js-comint.el is a comint mode for emacs which allows you to run a
+;;; compatible javascript repl such as Node.js, Spidermonkey or Rhino inside
+;;; emacs.
+;;; Additionally, it defines a few functions for sending javascript input to it
+;;; quickly.
 
 ;;  Usage:
 ;;  Put js-comint.el in your load path
 ;;  Add (require 'js-comint) to your .emacs
-;;  Set inferior-js-program-command to the execution command for running your javascript REPL
-;;  (setq inferior-js-program-command "/path/to/executable <args>")
+;;  Optionally, set the `inferior-js-program-command' string
+;;  and the `inferior-js-program-arguments' list to the executable that runs
+;;  the JS interpreter and the arguments to pass to it respectively.
+;;  E.g., the default is:
+;;  (setq inferior-js-program-command "node")
+;;  (setq inferior-js-program-arguments '("--interactive"))
+
+;; E.g. Set up the Rhino JAR downloaded from
+;; https://github.com/mozilla/rhino
+;; (setq inferior-js-program-command "java")
+;; (setq inferior-js-program-arguments '("-jar" "/absolute/path/to/rhino/js.jar"))
+
 ;;  Do: M-x run-js
 ;;  Away you go.
 
-;;  I've added the following couple of lines to my .emacs to take advantage of
+;;  If you have nvm, you can select the versions of node.js installed and run
+;;  them. This is done thanks to nvm.el
+;;  To enable nvm support, run (js-do-use-nvm)
+;;  The first time you start the JS interpreter with run-js, you will be asked
+;;  to select a version of node.js
+;;  If you want to change version of node js, run (js-select-node-version)
+
+;;  You can add  the following couple of lines to your .emacs to take advantage of
 ;;  cool keybindings for sending things to the javascript interpreter inside
 ;;  of Steve Yegge's most excellent js2-mode.
 
 ;; (add-hook 'js2-mode-hook '(lambda ()
-;;              (local-set-key "\C-x\C-e" 'js-send-last-sexp)
-;;              (local-set-key "\C-\M-x" 'js-send-last-sexp-and-go)
-;;              (local-set-key "\C-cb" 'js-send-buffer)
-;;              (local-set-key "\C-c\C-b" 'js-send-buffer-and-go)
-;;              (local-set-key "\C-cl" 'js-load-file-and-go)
-;;              ))
-
-;;  This is version 0.0.1, so I've only tested it on my own version of emacs which is currently:
-;;  GNU Emacs 22.0.90.1 (i386-apple-darwin8.8.1, Carbon Version 1.6.0) of 2006-10-28
-;;  Not sure if it'll work anywhere else, but it doesn't require anything apple-ish, just emacs-ish.
-
-;; Additionally, I've only tested this with rhino.  I'm sure it'll probably work with spidermonkey,
-;; though if it barfs let me know, and I'll update it.
-
-;; I'm a newbie elisper, so please let me know if I'm a. doing things the wrong way, b.
-;; making things work they way they shouldn't in the elisp world.
+;;                             (local-set-key "\C-x\C-e" 'js-send-last-sexp)
+;;                             (local-set-key "\C-\M-x" 'js-send-last-sexp-and-go)
+;;                             (local-set-key "\C-cb" 'js-send-buffer)
+;;                             (local-set-key "\C-c\C-b" 'js-send-buffer-and-go)
+;;                             (local-set-key "\C-cl" 'js-load-file-and-go)))
 
 ;;; History:
-;;
+;; * Version 0.0.3:
+;;   - add support to select node.js versions using nvm.el
+;; * Version 0.0.2:
+;;   - hosted on https://github.com/redguardtoo/js-comint
+;;   - use node.js by default.
+;;   - when loading file, detect what API to be used automatically
+;; * Version 0.0.1:
+;;   - original js-comint hosted on http://js-comint-el.sourceforge.net/
 
 ;;; Code:
 
+(require 'nvm)
 (require 'comint)
 
 (provide 'js-comint)
 
-(defcustom inferior-js-program-command "node --interactive" "Path to the javascript interpreter")
+(defcustom inferior-js-program-command "node"
+  "JavScript interpreter.")
+
+(defcustom inferior-js-program-arguments '("--interactive")
+  "List of command line arguments to pass to the JavaScript interpreter.")
 
 (defgroup inferior-js nil
   "Run a javascript process in a buffer."
@@ -83,9 +109,52 @@
   :type 'hook
   :group 'inferior-js)
 
+(defcustom js-use-nvm nil
+  "When t, use NVM.  Requires nvm.el."
+  :type 'boolean
+  :group 'inferior-js)
+
+(defvar js-prompt-regexp "^\\(?:> \\)"
+  "Prompt for `run-js'.")
+
+(defvar js-nvm-current-version nil "Current version of node.")
+
+(defun js-list-nvm-versions (prompt)
+  "List all available node versions from nvm prompting the user with PROMPT.
+Return a string representing the node version."
+  (let ((candidates (sort (mapcar 'car (nvm--installed-versions)) 'string<)))
+    (completing-read prompt
+                     candidates nil t nil
+                     nil
+                     (car candidates))))
+;;;###autoload
+(defun js-do-use-nvm ()
+  "Enable nvm."
+  (setq js-use-nvm t))
+
+;;;###autoload
+(defun js-select-node-version (&optional version)
+  "Use a given VERSION of node from nvm."
+  (interactive)
+  (if version
+      (setq js-nvm-current-version (nvm--find-exact-version-for version))
+    (let ((old-js-nvm js-nvm-current-version))
+      (setq js-nvm-current-version
+            (nvm--find-exact-version-for
+             (js-list-nvm-versions
+              (if old-js-nvm
+                  (format "Node version (current %s): " (car old-js-nvm))
+                "Node version: "))))))
+  (progn
+    (setq inferior-js-program-command
+          (concat
+           (car (last js-nvm-current-version))
+           "/bin"
+           "/node"))))
+
 (defun js--is-nodejs ()
   (string= "node"
-           (substring-no-properties inferior-js-program-command 0 4)))
+           (substring-no-properties inferior-js-program-command -4 nil)))
 
 (defun js--guess-load-file-cmd (filename)
   (let ((cmd (concat "require(\"" filename "\")\n")))
@@ -103,16 +172,28 @@ of `inferior-js-program-command').
 Runs the hook `inferior-js-mode-hook' \(after the `comint-mode-hook'
 is run).
 \(Type \\[describe-mode] in the process buffer for a list of commands.)"
-
-  (interactive (list (if current-prefix-arg
-                         (read-string "Run js: " inferior-js-program-command)
-                       inferior-js-program-command)))
+  (when js-use-nvm
+    (unless js-nvm-current-version
+      (js-select-node-version)))
+  (setenv "NODE_NO_READLINE" "1")
+  (interactive
+   (list
+    (when current-prefix-arg
+      (setq cmd
+            (read-string "Run js: "
+                         (mapconcat
+                          'identity
+                          (cons
+                           inferior-js-program-command
+                           inferior-js-program-arguments)
+                          " ")))
+      (setq inferior-js-program-arguments (split-string cmd))
+      (setq inferior-js-program-command (pop inferior-js-program-arguments)))))
   (if (not (comint-check-proc "*js*"))
-      (save-excursion (let ((cmdlist (split-string cmd)))
-                        (set-buffer (apply 'make-comint "js" (car cmdlist)
-                                           nil (cdr cmdlist)))
-                        (inferior-js-mode))))
-  (setq inferior-js-program-command cmd)
+      (save-excursion
+        (set-buffer (apply 'make-comint "js" inferior-js-program-command
+                           nil inferior-js-program-arguments))
+        (inferior-js-mode)))
   (setq inferior-js-buffer "*js*")
   (if (not dont-switch-p)
       (pop-to-buffer "*js*")))
@@ -227,5 +308,6 @@ Javascript source.
 
 "
   (use-local-map inferior-js-mode-map))
+
 
 ;;; js-comint.el ends here


### PR DESCRIPTION
Hi @redguardtoo, I have recently discussed with @rejeep in [nvm.el issue #6](https://github.com/rejeep/nvm.el/issues/6) the possibility to use nvm and node in a comint mode.

We think that the best place where this should go is js-comint, so I here is a PR to integrate nvm.
- require nvm.el and add opt-in support to use it
- update documentation
- update version and copyright information

There is a breaking change in which the js interpreter command and arguments are now customized with 2 variables (this is in the documentation). I think that this change makes the code easier to read and think about (e.g. no more string splitting and assumptions about what is the executable and what are the arguments).

I understand that this repo is supposed hold js-comint in maintenance mode only. But since the de-facto JS interpreter is now the node REPL, it's very useful to be able to run code against multiple versions.

Thank you for considering this PR.
