### PR TITLE
Fix byte-compile warnings by declaration position

### DIFF
--- a/js-comint.el
+++ b/js-comint.el
@@ -83,15 +83,15 @@
 (require 'nvm)
 (require 'comint)
 
+(defgroup inferior-js nil
+  "Run a javascript process in a buffer."
+  :group 'inferior-js)
+
 (defcustom inferior-js-program-command "node"
   "JavScript interpreter.")
 
 (defcustom inferior-js-program-arguments '("--interactive")
   "List of command line arguments to pass to the JavaScript interpreter.")
-
-(defgroup inferior-js nil
-  "Run a javascript process in a buffer."
-  :group 'inferior-js)
 
 (defcustom inferior-js-mode-hook nil
   "*Hook for customizing inferior-js mode."
@@ -107,6 +107,8 @@
   "Prompt for `run-js'.")
 
 (defvar js-nvm-current-version nil "Current version of node.")
+
+(defvar inferior-js-buffer)
 
 (defun js-list-nvm-versions (prompt)
   "List all available node versions from nvm prompting the user with PROMPT.
@@ -268,8 +270,6 @@ With argument, position cursor at end of buffer."
   (when eob-p
     (push-mark)
     (goto-char (point-max))))
-
-(defvar inferior-js-buffer)
 
 (defvar inferior-js-mode-map
   (let ((m (make-sparse-keymap)))


### PR DESCRIPTION
There are some byte-compile warning about this.

```
js-comint.el:86:1:Warning: defcustom for `inferior-js-program-command' fails
    to specify containing group
js-comint.el:86:1:Warning: defcustom for `inferior-js-program-command' fails
    to specify containing group
js-comint.el:89:1:Warning: defcustom for `inferior-js-program-arguments' fails
    to specify containing group
js-comint.el:89:1:Warning: defcustom for `inferior-js-program-arguments' fails
    to specify containing group
js-comint.el:186:9:Warning: assignment to free variable `inferior-js-buffer'

In js-send-region:
js-comint.el:195:23:Warning: reference to free variable `inferior-js-buffer'

In js-send-region-and-go:
js-comint.el:203:23:Warning: reference to free variable `inferior-js-buffer'

In js-load-file:
js-comint.el:248:25:Warning: reference to free variable `inferior-js-buffer'

In js-load-file-and-go:
js-comint.el:256:25:Warning: reference to free variable `inferior-js-buffer'

In switch-to-js:
js-comint.el:264:16:Warning: reference to free variable `inferior-js-buffer'
```
