### PR TITLE
Always display inferior process buffer after evaluation

### DIFF
--- a/js-comint.el
+++ b/js-comint.el
@@ -193,8 +193,9 @@ is run).
                  nil inferior-js-program-arguments)
         (inferior-js-mode)))
   (setq inferior-js-buffer "*js*")
-  (if (not dont-switch-p)
-      (pop-to-buffer "*js*")))
+  (if dont-switch-p
+      (display-buffer "*js*")
+    (pop-to-buffer "*js*")))
 
 ;;;###autoload
 (defun js-send-region (start end)


### PR DESCRIPTION
Previously, if the inferior process buffer is not being shown in any
window, one would have to manually bring it up after evaluating an
expression in order to see the results. With this change, the inferior
process buffer will always be displayed after evaluating an expression
so that one can alway see the results without having to bring up the
inferior process buffer.