### PR TITLE
Update URL

### DIFF
--- a/js-comint.el
+++ b/js-comint.el
@@ -8,7 +8,7 @@
 ;;; Maintainer: Chen Bin <chenbin.sh AT gmail DOT com>
 ;;; Created: 15 Feb 2014
 ;;; Version: 1.1.0
-;;; URL: https://github.com/js-comint/js-comint
+;;; URL: https://github.com/redguardtoo/js-comint
 ;;; Package-Requires: ()
 ;;; Keywords: javascript, node, inferior-mode, convenience
 


### PR DESCRIPTION
The old org doesn't exist anymore. Clicking on the URL directs to a 404 page. This fixes it.