### PR TITLE
defining our adjust-window-size-function

### DIFF
--- a/js-comint.el
+++ b/js-comint.el
@@ -422,6 +422,8 @@ If no region selected, you could manually input javascript expression."
   ;; Ignore duplicates
   (setq comint-input-ignoredups t)
   (add-hook 'comint-output-filter-functions 'js-comint-filter-output nil t)
+  (process-put (js-comint-get-process)
+               'adjust-window-size-function (lambda (_process _windows) ()))
   (use-local-map js-comint-mode-map)
   (ansi-color-for-comint-mode-on))
 


### PR DESCRIPTION
this PR fixes extra prompts inserted whenever there is a change in window configuration, e.g. resizing window, resizing frame, opening which key buffers, etc. 

the extra prompt is inserted by `window--adjust-process-windows` which is called after every change in window configuration. this function checks first if the process has defined its own function using `process-get` and if so calls it, else it calls a default window resizing function, which causes this problem. 

since we don't need any resizing configuration for a simple REPL the function does nothing.
