### PR TITLE
Update key bindings

### DIFF
--- a/README.org
+++ b/README.org
@@ -84,14 +84,12 @@ To enable nvm support, run
 (js-do-use-nvm)
 #+END_SRC
 
-The first time you start the JS interpreter with run-js, you will be asked to select a version of node.js. If you want to change version of node js, run `(js-select-node-version)`
+The first time you start the JS interpreter with run-js, you will be asked to select a version of node.js. If you want to change version of node js, run ~(js-select-node-version)~.
 
-You can add the following couple of lines to your .emacs to take advantage of cool key bindings for sending things to the javascript interpreter inside of Steve Yegge's most excellent js2-mode.
+You can add the following couple of lines to your .emacs/init file to take advantage of key bindings for sending things to the JavaScript REPL: 
 
 #+BEGIN_SRC elisp
-  (add-hook 'js2-mode-hook
-            (lambda ()
-              (local-set-key (kbd "C-x C-e") 'js-send-last-sexp)
-              (local-set-key (kbd "C-c b") 'js-send-buffer)
-              (local-set-key (kbd "C-c C-b") 'js-send-buffer-and-go)))
+  ; Remap Elisp's eval-last-sexp (C-x C-e) to eval JavaScript
+  (define-key js-mode-map [remap eval-last-sexp] #'js-comint-send-last-sexp))
+  (define-key js-mode-map (kbd "C-c b") 'js-send-buffer))
 #+END_SRC


### PR DESCRIPTION
I noticed that `js-send-last-sexp-and-go` isn't part of js2-mode or js-mode (anymore?). I updated the sample accordingly to rebind keys inside the `js-mode` keymap instead of adding a hook for buffer-local bindings.