### PR TITLE
Fixes to run under Emacs 27.1

### DIFF
--- a/js-comint.el
+++ b/js-comint.el
@@ -359,8 +359,8 @@ The environment variable \"NODE_PATH\" is setup by `js-comint-module-paths'."
 
 (defun js-comint-send-string (str)
   "Send STR to repl."
-  (let ((lines (string-lines str)))
-    (if (length= lines 1)
+  (let ((lines (split-string str "\r\n")))
+    (if (= (length lines) 1)
 	(comint-send-string (js-comint-get-process)
 			    (concat str "\n"))
       (comint-send-string (js-comint-get-process)


### PR DESCRIPTION
Hello, new user here. I'm using Emacs 27.1 (that's what's in current Debian Stable), and it seems that functions `length=` and `string-lines` were introduced in later versions. Not sure if this is complete, as I only tested a few `js-comint` commands.