### PR TITLE
Add tests for multiline statements, run tests in github workflow

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,16 @@
+name: Run tests across emacs versions
+on: [push, pull_request]
+jobs:
+  test-emacs-versions:
+    strategy:
+      matrix:
+        emacs-version: [26, 27, 28, 29]
+    runs-on: ubuntu-latest
+    container: silex/emacs:${{matrix.emacs-version}}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Install test dependencies
+        run: ./install-deps.sh
+      - name: Run tests
+        run: ./runtests.sh

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xeu
+
+apt-get update
+apt-get install -y nodejs
+apt-get clean

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -xeu
+
+cd "$(dirname $0)"
+emacs -Q --batch \
+      -l ert \
+      -l js-comint.el \
+      -l test-js-comint.el \
+      -f ert-run-tests-batch-and-exit

--- a/test-js-comint.el
+++ b/test-js-comint.el
@@ -1,0 +1,44 @@
+(defun js-comint-test-buffer-matches (regex)
+  "Search the js-comint buffer for the given regular expression.
+Return 't if a match is found, nil otherwise."
+  (with-current-buffer (js-comint-get-buffer)
+    (save-excursion
+      (goto-char (point-min))
+      (if (re-search-forward regex nil t) t nil))))
+
+(defun js-comint-test-output-matches (input regex)
+  "Verify that sending INPUT yields output that matches REGEX."
+
+  ;; Start an instance to run tests on.
+  (js-comint-reset-repl)
+
+  (sit-for 1)
+
+  (js-comint-send-string input)
+
+  (sit-for 1)
+
+  (js-comint-test-buffer-matches regex))
+
+(ert-deftest js-comint-test-multiline-dotchain-line-start ()
+  "Test multiline statement with dots at beginning of lines."
+  (should (js-comint-test-output-matches "[1, 2, 3]
+  .map((it) => it + 1)
+  .filter((it) => it > 0)
+  .reduce((prev, curr) => prev + curr, 0);" "^9$")))
+
+(ert-deftest js-comint-test-multiline-dotchain-line-start-dos ()
+  "Test multiline statement with dots at beginning of lines, with
+DOS line separators."
+  (should (js-comint-test-output-matches "[1, 2, 3]\r
+  .map((it) => it + 1)\r
+  .filter((it) => it > 0)\r
+  .reduce((prev, curr) => prev + curr, 0);\r
+" "^9$")))
+
+(ert-deftest js-comint-test-multiline-dotchain-line-end ()
+  "Test multiline statement with dots at end of lines."
+  (should (js-comint-test-output-matches "[1, 2, 3].
+map((it) => it + 1).
+filter((it) => it > 0).
+reduce((prev, curr) => prev + curr, 0);" "^9$")))


### PR DESCRIPTION
After I found out that I accidentally broke the code in #33, I thought that it would have been nice to have tests, and even nicer for the maintainer to have them run automatically, so here goes.

Note, I am not very fond of the sleep (`sit-for`) statements in the tests. I suppose this is essentially caused by comint making things essentially asynchronous, in which case this could probably be fixed by properly waiting for the JS prompt to reappear. I don't know yet how to do that, but I thought there is already enough material for a PR, even if only to discuss.
