### PR TITLE
Update args for repl.start()

### DIFF
--- a/js-comint.el
+++ b/js-comint.el
@@ -137,8 +137,12 @@
 (defvar js-comint-code-format
   (concat
    "process.stdout.columns = %d;"
-   "require('repl').start('%s', null, null, true, false, "
-   "require('repl')['REPL_MODE_' + '%s'.toUpperCase()])"))
+   "require('repl').start({
+\"prompt\": '%s',
+\"ignoreUndefined\": true,
+\"preview\": true,
+\"replMode\": require('repl')['REPL_MODE_' + '%s'.toUpperCase()]
+})"))
 
 (defvar js-nvm-current-version nil
   "Current version of node for js-comint.

--- a/js-comint.el
+++ b/js-comint.el
@@ -140,8 +140,7 @@
    "require('repl').start({
 \"prompt\": '%s',
 \"ignoreUndefined\": true,
-\"preview\": true,
-\"replMode\": require('repl')['REPL_MODE_' + '%s'.toUpperCase()]
+\"preview\": true
 })"))
 
 (defvar js-nvm-current-version nil
@@ -312,9 +311,8 @@ Create a new Javascript REPL process."
                                                js-comint-module-paths)))
            (all-paths-list (seq-remove 'string-empty-p all-paths-list))
            (local-node-path (string-join all-paths-list (js-comint--path-sep)))
-           (repl-mode (or (getenv "NODE_REPL_MODE") "magic"))
            (js-comint-code (format js-comint-code-format
-                          (window-width) js-comint-prompt repl-mode)))
+                          (window-width) js-comint-prompt)))
       (with-environment-variables (("NODE_NO_READLINE" "1")
                                    ("NODE_PATH" local-node-path))
         (pop-to-buffer

--- a/test-js-comint.el
+++ b/test-js-comint.el
@@ -116,3 +116,9 @@ reduce((prev, curr) => prev + curr, 0);" "^9$")))
       (setenv "NODE_PATH" original-env)
       (fset 'js-comint--suggest-module-path original-suggest)
       (js-comint-test-exit-comint))))
+
+(ert-deftest js-comint/test-strict-mode ()
+  "When NODE_REPL_MODE=strict should use strict mode."
+  (with-environment-variables (("NODE_REPL_MODE" "strict"))
+    ;; global variables are not allowed in strict mode
+    (js-comint-test-output-matches "foo = 5;" "Uncaught ReferenceError.*")))


### PR DESCRIPTION
### Minor fix
The `repl.start()` method was changed a while ago to take either an object arg or a string for the prompt: https://nodejs.org/docs/latest-v20.x/api/repl.html#replstartoptions

This updates the call to match the new API
```js
require('repl').start({
"prompt": '%s',
"ignoreUndefined": true,  // do not print undefined
"preview": true                 // when completing print out the type in a comment
})
```

Also, the NODE_REPL_MODE var is available in the inner REPL created by `repl.start()` so it doesn't need to be passed as an arg.